### PR TITLE
Media Queries Remix

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,24 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <style>
-    /* keep large map centered */
-    .leaflet-container {
-      margin: auto;
-    }
 
-    .leaflet-container h2 {
-      margin:0;
-    }
-    .leaflet-control-attribution {
-      display: none;
-    }
-/*
-
-    .leaflet-control{
-      position: 'topright'
-    } */
-  </style>
   <title>React App</title>
 </head>
 

--- a/client/src/assets/styles/style.css
+++ b/client/src/assets/styles/style.css
@@ -1,22 +1,38 @@
+body {
+  color: #252525;
+  font-family: "Lato", sans-serif;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  width: 100vw;
+  font-size: 16px;
+}
 
+a {
+  text-decoration: none;
+  cursor: pointer;
+  color: #232323;
+  transition: color 0.3s ease;
+}
 
- body {
-    color: #252525;
-    font-family: "Lato", sans-serif;
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    width: 100vw;
-    font-size: 16px;
+/* Map styles here */
 
+.leaflet-container {
+  width: 100vw;
+  height: 35vh;
+}
+
+.leaflet-container h2 {
+  margin: 0;
+}
+.leaflet-control-attribution {
+  display: none;
+}
+
+@media only screen and (min-width: 600px) {
+  .leaflet-container {
+    width: 80%;
+    height: 400px;
+    margin: auto;
   }
-  
-  
-  a {
-    text-decoration: none;
-    cursor: pointer;
-    color: #232323;
-    transition: color 0.3s ease;
-  }
-  
-  /* Nav bar styles -------> */
+}

--- a/client/src/components/homepage/Home.js
+++ b/client/src/components/homepage/Home.js
@@ -24,6 +24,7 @@ const Home = props => {
     line-height: 2.5vh;
     @media screen and (min-width: 600px) {
       font-size: 0.8rem;
+      width: 50%;
     }
   `;
 
@@ -44,6 +45,11 @@ const Home = props => {
     justify-content: space-between;
     height: 5vh;
     width: 99%;
+    @media screen and (min-width: 600px) {
+      width: 80%;
+      margin: auto;
+      text-align: right;
+    }
   `;
   const MaximiseMap = styled.button`
     background: #e71242;

--- a/client/src/components/homepage/map/LargeMap.js
+++ b/client/src/components/homepage/map/LargeMap.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { Map, TileLayer } from "react-leaflet";
 import MarkersList from "./MarkersList";
+import styles from "../../../assets/styles/style.css";
 
 const mapboxToken = require("../../../config.js");
 

--- a/client/src/components/homepage/map/MapWindow.js
+++ b/client/src/components/homepage/map/MapWindow.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { Map, TileLayer } from "react-leaflet";
 import MarkersList from "./MarkersList";
+import styles from "../../../assets/styles/style.css";
 
 const mapboxToken = require("../../../config.js");
 
@@ -11,11 +12,6 @@ const day = d.getDay(); // returns the current day as a value between 0-6 where 
 const hours = d.getHours();
 const minutes = d.getMinutes();
 const time = `${hours}:${minutes}`;
-
-const style = {
-  height: "35vh",
-  width: "100vw"
-};
 
 class MapWindow extends Component {
   constructor(props) {
@@ -130,7 +126,6 @@ class MapWindow extends Component {
             }}
             center={centre}
             zoom={zoomLevel}
-            style={style}
           >
             <TileLayer attribution={false} url={url} id="mapbox.streets" />
 

--- a/client/src/components/homepage/results/ResultItems.js
+++ b/client/src/components/homepage/results/ResultItems.js
@@ -5,13 +5,16 @@ import arrow from "../../../assets/arrow.png";
 // import { sortByTime, getTimeOptionArr } from "../../../helpers/getStatus";
 const geolib = require("geolib");
 
-const ResultItems = props => {
+const ResultItems = (props) => {
   const Results = styled.div`
     background: #e71242;
     padding-top: 1rem;
     padding: 0.75em;
+    max-width: 500px;
     @media screen and (min-width: 600px) {
       width: 500px;
+      margin-left: 10%;
+      padding: 1%;
     }
   `;
   const Item = styled.div`
@@ -43,6 +46,9 @@ const ResultItems = props => {
     min-height: 25vh;
     justify-content: space-between;
     margin-bottom: 5%;
+    @media screen and (min-width: 600px) {
+      width: 100%;
+    }
   `;
   const NextPage = styled.button`
     border: none;
@@ -58,7 +64,6 @@ const ResultItems = props => {
   const NoResults = styled.div`
     color: white;
     text-align: center;
-    height: 20vh;
   `;
 
   const d = new Date();
@@ -153,9 +158,7 @@ const ResultItems = props => {
           <Flex>
             <Item key={a.Name + a.Description}>
               <Title>{a.Name}</Title>
-              <br />
-              {a.Description}
-              <br />
+              <p>{a.Description}</p>
               {a.Address_Line_3}
               <br />
               {props.lat ? (

--- a/client/src/components/homepage/search/SearchForm.js
+++ b/client/src/components/homepage/search/SearchForm.js
@@ -8,16 +8,20 @@ const FormStyle = styled.form`
   color: white;
   flex-direction: column;
   padding: 2%;
-  height: 33vh;
+  height: 45vh;
+  max-width: 500px;
   @media screen and (min-width: 600px) {
     width: 500px;
+    margin-left: 10%;
+    padding: 1%;
   }
 `;
 const FlexRow = styled.div`
-  display: inherit;
+  display: flex;
   flex-direction: row;
   margin-top: 3vh;
   justify-content: space-around;
+  align-items: center;
 `;
 const PostcodeSearchBar = styled.input`
   display: flex;
@@ -31,7 +35,7 @@ const PostcodeSearchBar = styled.input`
   font: lato;
   color: white;
   font-size: 18px;
-  margin-top: 2em;
+  margin-top: 1em;
   &::placeholder {
     color: white;
   }
@@ -59,7 +63,7 @@ const FakeRadioOn = styled.label`
   padding: 2%;
   color: #e71242;
   background: white;
-  border: 2px solid #e71242;
+  border: 2px solid white;
   text-align: center;
 `;
 
@@ -67,11 +71,12 @@ const Submit = styled.button`
   display: flex;
   color: white;
   background-color: none;
+  margin-top: 3%;
 `;
 const Question = styled.p`
-  padding-top: 4em;
+  padding-top: 2em;
   font-size: 1rem;
-  margin: 0 auto;
+  margin: 0 auto 3% auto;
 `;
 const LabelSmall = styled.label`
   font-size: 1 rem;
@@ -81,6 +86,7 @@ const LabelSmall = styled.label`
 const Padding = styled.div`
   margin: 5%;
   padding-top: 2em;
+  height: 2em;
 `;
 
 const CheckBox = styled.input`
@@ -89,10 +95,20 @@ const CheckBox = styled.input`
   width: 2rem;
 `;
 
+//Makes space for error message so that things don't overlap
+
+const ErrMessage = styled.div`
+  padding: 2%;
+`;
+
 const SearchForm = props => {
   return (
     <FormStyle>
-      {props.postcodeErrorMsg ? <p>{props.postcodeErrorMsg}</p> : ""}
+      {props.postcodeErrorMsg ? (
+        <ErrMessage>{props.postcodeErrorMsg}</ErrMessage>
+      ) : (
+        <ErrMessage />
+      )}
       <FlexRow className="flexrow">
         <PostcodeSearchBar
           type="text"


### PR DESCRIPTION
Map now shrinks on desktop
Search form and results list now align in desktop
No postcode error message no longer overlapping (esp on Nexus 5 and iphone 4)

To do (style):
- [ ] Decide if we're using a banner on desktop view(we're not using it on mobile view so is it weird? Confusing? Necessary?) and then style voucher and detailed results page
- [ ] Decide on "home" button name/image
- [ ] Hide button behind magnifying glass in desktop
- [ ] Further styling for home page in desktop? 
- [ ] in order to stop "see other support" being hidden if the postcode is wrong/iphone4/nexus5 I had to do somethings which mean that the results section is hidden. It might not be obvious you need to scroll down. A less tedious fix might be to make the header and home link a little smaller or somehow insert link so that the view moves down the page. 

Please don't make the mistake i made with adding divs around the form and results - the postcode input stops working. Keep checking as you're working. And try not to touch the original css but add media queries instead. 🤗🤗🤗🤗